### PR TITLE
Fixed missing includes

### DIFF
--- a/src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/Edbg.hpp
+++ b/src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/Edbg.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 
 namespace Bloom::DebugToolDrivers::Protocols::CmsisDap::Edbg
 {

--- a/src/ProjectConfig.hpp
+++ b/src/ProjectConfig.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <yaml-cpp/yaml.h>
+#include <optional>
 
 namespace Bloom
 {


### PR DESCRIPTION
Hello,
I've tried installing bloom on my system (Manjaro Linux) and the installation failed due to multiple compilation errors caused by missing includes.

I tracked it down to 2missing headers (`optional` & `cstddef`) and managed to completely resolve the issue and compile.
This fix shouldn't impact already working builds and might fix this issue for others.

The errors i was getting were:
1. `"optional" in namespace "std" does not name a template type`
All over the `src/Logger/Logger.cpp` and `src/ProjectConfig.hpp` files, since `Logger.hpp` included `ProjectConfig.hpp`  i decided to import `optional` here.

2. `"size_t" does not name a type`
In the file `src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/AVR/AvrEvent.hpp:32:23`
I figured that this might happen in other files in the EDBG collection so i decided to add the include `cstddef` in the common header `src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/Edbg.hpp`.
This header satisfies the `size_t` type while having a small overhead (only 7 types specified).

Feel free to make changes you feel necessary or contact me if you have any questions.

Sincerely, Shyne.