### PR TITLE
Add missing includes to fix build

### DIFF
--- a/src/DebugServer/Gdb/GdbDebugServerConfig.hpp
+++ b/src/DebugServer/Gdb/GdbDebugServerConfig.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "src/ProjectConfig.hpp"
 
 namespace Bloom::DebugServer::Gdb

--- a/src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/AVR/AvrEvent.cpp
+++ b/src/DebugToolDrivers/Protocols/CMSIS-DAP/VendorSpecific/EDBG/AVR/AvrEvent.cpp
@@ -1,4 +1,5 @@
 #include "AvrEvent.hpp"
+#include <cstdint>
 
 #include "src/Exceptions/Exception.hpp"
 

--- a/src/Helpers/Thread.hpp
+++ b/src/Helpers/Thread.hpp
@@ -2,6 +2,7 @@
 
 #include <csignal>
 #include <cassert>
+#include <string>
 
 #include "SyncSafe.hpp"
 


### PR DESCRIPTION
Hi there,

first of all great work on this project! I tried to get avarice working with debugwire but wasn't very successful. Then I found this project by chance and it improved the whole AVR experience on linux a lot for me :-)

When trying to compile on latest  fedora, the project failed to build however. It seems some includes in some files are missing. Probably new compilers are a bit more picky or the system headers did include those headers before. The changes here fix the build for fedora 38. Fedora rawhide / 39 has another issue, but I'll open a new bug report for that.